### PR TITLE
feat(builder): inherit process stdin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ impl CliArgs {
             .collect::<Vec<&str>>();
 
         store_builder.args(args)?;
+        store_builder.inherit_stdin();
 
         Ok(())
     }


### PR DESCRIPTION
ref https://github.com/fermyon/spin-trigger-command/issues/37

This commit unconditionally inherits the `spin up` process' stdin.

Given the goal of this trigger is to execute Wasm components to completion, it makes sense to inherit stdin from the parent's process and potentially block on waiting for user input.
